### PR TITLE
Update image tags to 20230118.1 MCR releases

### DIFF
--- a/azurecontainerapps/src/ContainerAppHelper.ts
+++ b/azurecontainerapps/src/ContainerAppHelper.ts
@@ -1,8 +1,8 @@
 import * as tl from 'azure-pipelines-task-lib/task';
 import { CommandHelper } from './CommandHelper';
 
-const ORYX_CLI_IMAGE: string = 'cormtestacr.azurecr.io/oryx/cli:latest';
-const ORYX_BUILDER_IMAGE: string = 'cormtestacr.azurecr.io/builder:latest';
+const ORYX_CLI_IMAGE: string = 'mcr.microsoft.com/oryx/cli:builder-debian-buster-20230118.1';
+const ORYX_BUILDER_IMAGE: string = 'mcr.microsoft.com/oryx/builder:20230118.1';
 
 export class ContainerAppHelper {
     /**


### PR DESCRIPTION
Updates the images used in this action to the official MCR releases with the `20230118.1` tag.