### PR TITLE
Fix incorrect argument validation bug

### DIFF
--- a/azurecontainerapps/Strings/resources.resjson/en-US/resources.resjson
+++ b/azurecontainerapps/Strings/resources.resjson/en-US/resources.resjson
@@ -58,7 +58,7 @@
   "loc.messages.ErrorCodeFormat": "Error Code: [%s]",
   "loc.messages.ErrorMessageFormat": "Error: %s",
   "loc.messages.FoundAppSourceDockerfileMessage": "Found existing Dockerfile in provided application source at path '%s'; image will be built from this Dockerfile.",
-  "loc.messages.InvalidArgumentsMessage": "The arguments appSourcePath and acrName must either be provided together or not at all.",
+  "loc.messages.MissingAcrNameMessage": "The acrName argument must also be provided if the appSourcePath argument is provided.",
   "loc.messages.MissingImageToDeployMessage": "The argument imageToDeploy must be provided if neither appSourcePath nor acrName are provided.",
   "loc.messages.PackCliInstallFailed": "Unable to install pack CLI.",
   "loc.messages.PushImageToAcrFailed": "Unable to push image '%s' to ACR.",

--- a/azurecontainerapps/azurecontainerapps.ts
+++ b/azurecontainerapps/azurecontainerapps.ts
@@ -37,10 +37,10 @@ export class azurecontainerapps {
             // Get the previously built image to deploy, if provided
             let imageToDeploy: string = tl.getInput('imageToDeploy', false);
 
-            // Ensure that appSourcePath and acrName are either provided together or not at all
-            if (util.isNullOrEmpty(appSourcePath) != util.isNullOrEmpty(acrName)) {
-                tl.error(tl.loc('InvalidArgumentsMessage'));
-                throw Error(tl.loc('InvalidArgumentsMessage'));
+            // Ensure that acrName is also provided if appSourcePath is provided
+            if (!util.isNullOrEmpty(appSourcePath) && util.isNullOrEmpty(acrName)) {
+                tl.error(tl.loc('MissingAcrNameMessage'));
+                throw Error(tl.loc('MissingAcrNameMessage'));
             }
 
             // Ensure that if neither appSourcePath nor acrName are provided that imageToDeploy is provided

--- a/azurecontainerapps/task.json
+++ b/azurecontainerapps/task.json
@@ -6,7 +6,7 @@
     "description": "An Azure DevOps Task to build and deploy Azure Container Apps.",
     "author": "Microsoft Corporation",
     "helpMarkDown": "[Learn more about this task](http://github.com/Azure/container-apps-deploy-pipelines-task)",
-    "releaseNotes": "Released new AzureContainerAppsRC task for building and deploying Azure Container Apps.",
+    "releaseNotes": "Fixed incorrect argument validation bug that prevented acrName being provided without appSourcePath.",
     "category": "Deploy",
     "visibility": [
         "Build",
@@ -19,7 +19,7 @@
     "version": {
         "Major": 0,
         "Minor": 1,
-        "Patch": 8
+        "Patch": 9
     },
     "minimumAgentVersion": "2.144.0",
     "instanceNameFormat": "Azure Container Apps Deploy (Release Candidate)",
@@ -180,7 +180,7 @@
         "ErrorCodeFormat": "Error Code: [%s]",
         "ErrorMessageFormat": "Error: %s",
         "FoundAppSourceDockerfileMessage": "Found existing Dockerfile in provided application source at path '%s'; image will be built from this Dockerfile.",
-        "InvalidArgumentsMessage": "The arguments appSourcePath and acrName must either be provided together or not at all.",
+        "MissingAcrNameMessage": "The acrName argument must also be provided if the appSourcePath argument is provided.",
         "MissingImageToDeployMessage": "The argument imageToDeploy must be provided if neither appSourcePath nor acrName are provided.",
         "PackCliInstallFailed": "Unable to install pack CLI.",
         "PushImageToAcrFailed": "Unable to push image '%s' to ACR.",

--- a/azurecontainerapps/task.loc.json
+++ b/azurecontainerapps/task.loc.json
@@ -19,7 +19,7 @@
   "version": {
     "Major": 0,
     "Minor": 1,
-    "Patch": 8
+    "Patch": 9
   },
   "minimumAgentVersion": "2.144.0",
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",
@@ -135,7 +135,7 @@
       "helpMarkDown": "ms-resource:loc.input.help.targetPort"
     },
     {
-      "name": "targetPort",
+      "name": "location",
       "type": "string",
       "label": "ms-resource:loc.input.label.location",
       "required": false,
@@ -180,7 +180,7 @@
     "ErrorCodeFormat": "ms-resource:loc.messages.ErrorCodeFormat",
     "ErrorMessageFormat": "ms-resource:loc.messages.ErrorMessageFormat",
     "FoundAppSourceDockerfileMessage": "ms-resource:loc.messages.FoundAppSourceDockerfileMessage",
-    "InvalidArgumentsMessage": "ms-resource:loc.messages.InvalidArgumentsMessage",
+    "MissingAcrNameMessage": "ms-resource:loc.messages.MissingAcrNameMessage",
     "MissingImageToDeployMessage": "ms-resource:loc.messages.MissingImageToDeployMessage",
     "PackCliInstallFailed": "ms-resource:loc.messages.PackCliInstallFailed",
     "PushImageToAcrFailed": "ms-resource:loc.messages.PushImageToAcrFailed",

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -2,7 +2,7 @@
     "manifestVersion": 1,
     "id": "AzureContainerAppsRC",
     "name": "Azure Container Apps Deploy (Release Candidate)",
-    "version": "0.1.8",
+    "version": "0.1.9",
     "publisher": "microsoft-oryx",
     "public": true,
     "targets": [


### PR DESCRIPTION
Resolves issue https://github.com/Azure/container-apps-deploy-pipelines-task/issues/11 -- fixes an issue where `acrName` is no longer able to be provided without the `appSourcePath` argument, disallowing users to provide `acrName` with `imageToDeploy` to authenticate access to the ACR instance that the image was previously deployed to.