### PR TITLE
Add telemetry to RC ADO Task

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,24 +8,6 @@ The `AzureContainerAppsRC` task found in this repository is the _Release Candida
 of this Release Candidate task is to offer users immediate early access to features, bug fixes and patches that will
 eventually be rolled out in the official `AzureContainerApps` task at the end of every three week sprint.
 
-## Running this task on Microsoft-hosted agents
-
-If you are running this task on a
-[Microsoft-hosted agent](https://learn.microsoft.com/en-us/azure/devops/pipelines/agents/hosted), you may find that this
-task is _not_ able to run successfully with the following operating systems:
-
-- macOS
-  - The [macOS runners](https://github.com/actions/runner-images#available-images) provided by Microsoft do not come
-  installed with Docker (more information [here](https://github.com/actions/runner-images/issues/17#issuecomment-614726536));
-  as a result, this task is not able to run any `docker` commands, such as pushing the built runnable application images
-  to ACR.
-- Windows
-  - The [Windows runners](https://github.com/actions/runner-images#available-images) provided by Microsoft comes with
-  Docker installed, but by default, Linux-based images are unable to be pulled down; as a result, this task is not able
-  to pull down the Oryx builder to create runnable application images from provided application source.
-
-Please see the below **Docker** prerequisite section for more information.
-
 ## Description
 
 This Azure Pipelines Task allows users to easily deploy their application source to an
@@ -45,6 +27,37 @@ with a call to `docker build` and the Container App will be created or updated b
 
 If a previously built image has already been pushed to the ACR instance and is provided to this task, no application
 source is required and the image will be used when creating or updating the Container App.
+
+## Running this task on Microsoft-hosted agents
+
+If you are running this task on a
+[Microsoft-hosted agent](https://learn.microsoft.com/en-us/azure/devops/pipelines/agents/hosted), you may find that this
+task is _not_ able to run successfully with the following operating systems:
+
+- macOS
+  - The [macOS runners](https://github.com/actions/runner-images#available-images) provided by Microsoft do not come
+  installed with Docker (more information [here](https://github.com/actions/runner-images/issues/17#issuecomment-614726536));
+  as a result, this task is not able to run any `docker` commands, such as pushing the built runnable application images
+  to ACR.
+- Windows
+  - The [Windows runners](https://github.com/actions/runner-images#available-images) provided by Microsoft comes with
+  Docker installed, but by default, Linux-based images are unable to be pulled down; as a result, this task is not able
+  to pull down the Oryx builder to create runnable application images from provided application source.
+
+Please see the below **Docker** prerequisite section for more information.
+
+## Data/Telemetry Collection Notice
+
+By default, this Azure DevOps Task collects the following pieces of data for Microsoft:
+- The Container App build and deploy scenario targeted by the user
+  - _i.e._, used the Oryx++ Builder, used a provided/found Dockerfile, or provided a previously built image
+  - _Note_: the image name is _not_ collected
+- The processing time of the task, in milliseconds
+- The result of the task
+  - _i.e._, succeeded or failed
+- If the Oryx++ Builder is used, events and metrics relating to building the provided application using Oryx
+
+If you want to disable data collection, please set the `disableTelemetry` argument to `true`.
 
 ## Prerequisites
 
@@ -166,6 +179,7 @@ need to be provided in order for this task to successfully run using one of the 
 | `targetPort`              | No       | The target port that the Container App will listen on. If not provided, this value will be "80" for Python applications and "8080" for all other supported platforms. |
 | `location`                | No       | The location that the Container App (and other created resources) will be deployed to. To view locations suitable for creating the Container App in, please run the following: `az provider show -n Microsoft.App --query "resourceTypes[?resourceType=='containerApps'].locations"` |
 | `environmentVariables`    | No       | A list of environment variable(s) for the container. Space-separated values in 'key=value' format. Empty string to clear existing values. Prefix value with 'secretref:' to reference a secret. |
+| `disableTelemetry`        | No       | If set to `true`, no telemetry will be collected by this Azure DevOps Task. If set to `false`, or if this argument is not provided, telemetry will be sent to Microsoft about the Container App build and deploy scenario targeted by this Azure DevOps Task. |
 
 ## Usage
 

--- a/azurecontainerapps/Strings/resources.resjson/en-US/resources.resjson
+++ b/azurecontainerapps/Strings/resources.resjson/en-US/resources.resjson
@@ -58,6 +58,7 @@
   "loc.messages.ErrorCodeFormat": "Error Code: [%s]",
   "loc.messages.ErrorMessageFormat": "Error: %s",
   "loc.messages.FoundAppSourceDockerfileMessage": "Found existing Dockerfile in provided application source at path '%s'; image will be built from this Dockerfile.",
+  "loc.messages.LogTelemetryFailed": "Unable to log telemetry to Application Insights.",
   "loc.messages.MissingAcrNameMessage": "The acrName argument must also be provided if the appSourcePath argument is provided.",
   "loc.messages.MissingImageToDeployMessage": "The argument imageToDeploy must be provided if neither appSourcePath nor acrName are provided.",
   "loc.messages.PackCliInstallFailed": "Unable to install pack CLI.",

--- a/azurecontainerapps/azurecontainerapps.ts
+++ b/azurecontainerapps/azurecontainerapps.ts
@@ -12,11 +12,7 @@ const util = new Utility();
 export class azurecontainerapps {
 
     public static async runMain(): Promise<void> {
-        let disableTelemetry = false;
-        try {
-            disableTelemetry = tl.getBoolInput('disableTelemetry', false);
-        }
-        finally {}
+        let disableTelemetry = tl.getBoolInput('disableTelemetry', false);
 
         // Set up TelemetryHelper for managing telemetry calls
         const telemetryHelper: TelemetryHelper = new TelemetryHelper(disableTelemetry);
@@ -221,12 +217,13 @@ export class azurecontainerapps {
             telemetryHelper.setSuccessfulResult();
         } catch (err) {
             tl.setResult(tl.TaskResult.Failed, err.message);
+            telemetryHelper.setFailedResult();
         } finally {
             // Logout of Azure if logged in during this task session
             authHelper.logoutAzure();
 
-            // Log telemetry for this task run (will do nothing if telemetry was previously disabled)
-            telemetryHelper.log();
+            // If telemetry is enabled, will log metadata for this task run
+            telemetryHelper.sendLogs();
         }
     }
 }

--- a/azurecontainerapps/azurecontainerapps.ts
+++ b/azurecontainerapps/azurecontainerapps.ts
@@ -72,7 +72,7 @@ export class azurecontainerapps {
             const acrPassword: string = tl.getInput('acrPassword', false);
 
             // Login to ACR if credentials were provided
-            if (!util.isNullOrEmpty(acrUsername) && !util.isNullOrEmpty(acrPassword)) {
+            if (!util.isNullOrEmpty(acrName) && !util.isNullOrEmpty(acrUsername) && !util.isNullOrEmpty(acrPassword)) {
                 console.log(tl.loc('AcrUsernamePasswordLoginMessage'));
                 new ContainerRegistryHelper().loginAcrWithUsernamePassword(acrName, acrUsername, acrPassword);
                 optionalCmdArgs.push(
@@ -82,7 +82,7 @@ export class azurecontainerapps {
             }
 
             // Login to ACR with access token if no credentials were provided
-            if (util.isNullOrEmpty(acrUsername) || util.isNullOrEmpty(acrPassword)) {
+            if (!util.isNullOrEmpty(acrName) && (util.isNullOrEmpty(acrUsername) || util.isNullOrEmpty(acrPassword))) {
                 console.log(tl.loc('AcrAccessTokenLoginMessage'));
                 await new ContainerRegistryHelper().loginAcrWithAccessTokenAsync(acrName);
             }

--- a/azurecontainerapps/azurecontainerapps.ts
+++ b/azurecontainerapps/azurecontainerapps.ts
@@ -217,7 +217,7 @@ export class azurecontainerapps {
             telemetryHelper.setSuccessfulResult();
         } catch (err) {
             tl.setResult(tl.TaskResult.Failed, err.message);
-            telemetryHelper.setFailedResult();
+            telemetryHelper.setFailedResult(err.message);
         } finally {
             // Logout of Azure if logged in during this task session
             authHelper.logoutAzure();

--- a/azurecontainerapps/package-lock.json
+++ b/azurecontainerapps/package-lock.json
@@ -38,9 +38,9 @@
       "integrity": "sha512-NYrtPht0wGzhwe9+/idPaBB+TqkY9AhTvOLMkThm0IoEfLaiVQZwBwyJ5puCkO3AUCWrmcoePjp2mbFocKy4SQ=="
     },
     "node_modules/@types/node": {
-      "version": "16.18.11",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.11.tgz",
-      "integrity": "sha512-3oJbGBUWuS6ahSnEq1eN2XrCyf4YsWI8OyCvo7c64zQJNplk3mO84t53o8lfTk+2ji59g5ycfc6qQ3fdHliHuA=="
+      "version": "16.18.12",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.12.tgz",
+      "integrity": "sha512-vzLe5NaNMjIE3mcddFVGlAXN1LEWueUsMsOJWaT6wWMJGyljHAWHznqfnKUQWGzu7TLPrGvWdNAsvQYW+C0xtw=="
     },
     "node_modules/@types/q": {
       "version": "1.0.7",
@@ -631,9 +631,9 @@
       "integrity": "sha512-NYrtPht0wGzhwe9+/idPaBB+TqkY9AhTvOLMkThm0IoEfLaiVQZwBwyJ5puCkO3AUCWrmcoePjp2mbFocKy4SQ=="
     },
     "@types/node": {
-      "version": "16.18.11",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.11.tgz",
-      "integrity": "sha512-3oJbGBUWuS6ahSnEq1eN2XrCyf4YsWI8OyCvo7c64zQJNplk3mO84t53o8lfTk+2ji59g5ycfc6qQ3fdHliHuA=="
+      "version": "16.18.12",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.12.tgz",
+      "integrity": "sha512-vzLe5NaNMjIE3mcddFVGlAXN1LEWueUsMsOJWaT6wWMJGyljHAWHznqfnKUQWGzu7TLPrGvWdNAsvQYW+C0xtw=="
     },
     "@types/q": {
       "version": "1.0.7",

--- a/azurecontainerapps/src/ContainerAppHelper.ts
+++ b/azurecontainerapps/src/ContainerAppHelper.ts
@@ -37,10 +37,11 @@ export class ContainerAppHelper {
                 });
 
                 new Utility().throwIfError(
-                    tl.execSync('az', command)
+                    tl.execSync('az', command),
+                    tl.loc('CreateOrUpdateContainerAppFailed')
                 );
             } catch (err) {
-                tl.error(tl.loc('CreateOrUpdateContainerAppFailed'));
+                tl.error(err.message);
                 throw err;
             }
     }
@@ -63,10 +64,11 @@ export class ContainerAppHelper {
                 }
 
                 new Utility().throwIfError(
-                    tl.execSync(PACK_CMD, `build ${imageToDeploy} --path ${appSourcePath} --builder ${ORYX_BUILDER_IMAGE} --run-image mcr.microsoft.com/oryx/${runtimeStack} ${telemetryArg}`)
+                    tl.execSync(PACK_CMD, `build ${imageToDeploy} --path ${appSourcePath} --builder ${ORYX_BUILDER_IMAGE} --run-image mcr.microsoft.com/oryx/${runtimeStack} ${telemetryArg}`),
+                    tl.loc('CreateImageWithBuilderFailed')
                 );
             } catch (err) {
-                tl.error(tl.loc('CreateImageWithBuilderFailed'));
+                tl.error(err.message);
                 throw err;
             }
     }
@@ -85,10 +87,11 @@ export class ContainerAppHelper {
             tl.debug(`Attempting to create a runnable application image from the provided/found Dockerfile "${dockerfilePath}" with image name "${imageToDeploy}"`);
             try {
                 new Utility().throwIfError(
-                    tl.execSync('docker', `build --tag ${imageToDeploy} --file ${dockerfilePath} ${appSourcePath}`)
+                    tl.execSync('docker', `build --tag ${imageToDeploy} --file ${dockerfilePath} ${appSourcePath}`),
+                    tl.loc('CreateImageWithDockerfileFailed')
                 );
             } catch (err) {
-                tl.error(tl.loc('CreateImageWithDockerfileFailed'));
+                tl.error(err.message);
                 throw err;
             }
     }
@@ -104,7 +107,8 @@ export class ContainerAppHelper {
             // Use 'oryx dockerfile' command to determine the runtime stack to use and write it to a temp file
             const dockerCommand: string = `run --rm -v ${appSourcePath}:/app ${ORYX_CLI_IMAGE} /bin/bash -c "oryx dockerfile /app | head -n 1 | sed 's/ARG RUNTIME=//' >> /app/oryx-runtime.txt"`;
             new Utility().throwIfError(
-                tl.execSync('docker', dockerCommand)
+                tl.execSync('docker', dockerCommand),
+                tl.loc('DetermineRuntimeStackFailed', appSourcePath)
             );
 
             // Read the temp file to get the runtime stack into a variable
@@ -126,7 +130,7 @@ export class ContainerAppHelper {
 
             return runtimeStack;
         } catch (err) {
-            tl.error(tl.loc('DetermineRuntimeStackFailed', appSourcePath));
+            tl.error(err.message);
             throw err;
         }
     }
@@ -139,10 +143,11 @@ export class ContainerAppHelper {
         tl.debug('Setting the Oryx++ Builder as the default builder via the pack CLI');
         try {
             new Utility().throwIfError(
-                tl.execSync(PACK_CMD, `config default-builder ${ORYX_BUILDER_IMAGE}`)
+                tl.execSync(PACK_CMD, `config default-builder ${ORYX_BUILDER_IMAGE}`),
+                tl.loc('SetDefaultBuilderFailed')
             );
         } catch (err) {
-            tl.error(tl.loc('SetDefaultBuilderFailed'));
+            tl.error(err.message);
             throw err;
         }
     }

--- a/azurecontainerapps/src/ContainerRegistryHelper.ts
+++ b/azurecontainerapps/src/ContainerRegistryHelper.ts
@@ -46,10 +46,11 @@ export class ContainerRegistryHelper {
         tl.debug(`Attempting to push image "${imageToPush}" to ACR`);
         try {
             new Utility().throwIfError(
-                tl.execSync('docker', `push ${imageToPush}`)
+                tl.execSync('docker', `push ${imageToPush}`),
+                tl.loc('PushImageToAcrFailed', imageToPush)
             );
         } catch (err) {
-            tl.error(tl.loc('PushImageToAcrFailed', imageToPush));
+            tl.error(err.message);
             throw err;
         }
     }

--- a/azurecontainerapps/src/TelemetryHelper.ts
+++ b/azurecontainerapps/src/TelemetryHelper.ts
@@ -1,0 +1,67 @@
+import * as tl from 'azure-pipelines-task-lib/task';
+import { Utility } from './Utility';
+
+const ORYX_CLI_IMAGE: string = "mcr.microsoft.com/oryx/cli:debian-buster-20230207.2";
+
+export class TelemetryHelper {
+    readonly disableTelemetry: boolean = false;
+
+    private scenario: string;
+    private result: string;
+    private taskStartMilliseconds: number;
+
+    constructor(disableTelemetry: boolean) {
+        this.disableTelemetry = disableTelemetry;
+        this.scenario = "N/A";
+        this.result = "failed";
+        this.taskStartMilliseconds = Date.now();
+    }
+
+    /**
+     * Sets the tracked result property to "succeeded".
+     */
+    public setSuccessfulResult() {
+        this.result = "succeeded";
+    }
+
+    /**
+     * Sets the tracked scenario property to "used-builder".
+     */
+    public setBuilderScenario() {
+        this.scenario = "used-builder";
+    }
+
+    /**
+     * Sets the tracked scenario property to "used-dockerfile".
+     */
+    public setDockerfileScenario() {
+        this.scenario = "used-dockerfile";
+    }
+
+    /**
+     * Sets the tracked scenario property to "used-image".
+     */
+    public setImageScenario() {
+        this.scenario = "used-image";
+    }
+
+    /**
+     * If telemetry is enabled, uses the "oryx telemetry" command to log metadata about this task execution.
+     */
+    public log() {
+        const taskLengthMilliseconds = Date.now() - this.taskStartMilliseconds;
+        if (!this.disableTelemetry) {
+            tl.debug(`Telemetry enabled; logging metadata about task result, length and scenario targeted.`);
+            try {
+                const dockerCommand = `run --rm ${ORYX_CLI_IMAGE} /bin/bash -c "oryx telemetry --event-name 'ContainerAppsPipelinesTaskRC' ` +
+                `--processing-time '${taskLengthMilliseconds}' --property 'result=${this.result}' --property 'scenario=${this.scenario}'"`
+                new Utility().throwIfError(
+                    tl.execSync('docker', dockerCommand)
+                );
+            } catch (err) {
+                tl.error(tl.loc('LogTelemetryFailed'));
+                throw err;
+            }
+        }
+    }
+}

--- a/azurecontainerapps/task.json
+++ b/azurecontainerapps/task.json
@@ -19,7 +19,7 @@
     "version": {
         "Major": 0,
         "Minor": 1,
-        "Patch": 10
+        "Patch": 11
     },
     "minimumAgentVersion": "2.144.0",
     "instanceNameFormat": "Azure Container Apps Deploy (Release Candidate)",

--- a/azurecontainerapps/task.json
+++ b/azurecontainerapps/task.json
@@ -147,6 +147,13 @@
             "label": "Environment variables",
             "required": false,
             "helpMarkDown": "A list of environment variable(s) for the container. Space-separated values in 'key=value' format. Empty string to clear existing values. Prefix value with 'secretref:' to reference a secret."
+        },
+        {
+            "name": "disableTelemetry",
+            "type": "boolean",
+            "label": "Disable telemetry",
+            "required": false,
+            "helpMarkDown": "If set to 'true', no telemetry will be collected by this Azure DevOps Task. If set to 'false', or if this argument is not provided, telemetry will be sent to Microsoft about the Container App build and deploy scenario targeted by this Azure DevOps Task."
         }
     ],
     "execution": {
@@ -180,6 +187,7 @@
         "ErrorCodeFormat": "Error Code: [%s]",
         "ErrorMessageFormat": "Error: %s",
         "FoundAppSourceDockerfileMessage": "Found existing Dockerfile in provided application source at path '%s'; image will be built from this Dockerfile.",
+        "LogTelemetryFailed": "Unable to log telemetry to Application Insights.",
         "MissingAcrNameMessage": "The acrName argument must also be provided if the appSourcePath argument is provided.",
         "MissingImageToDeployMessage": "The argument imageToDeploy must be provided if neither appSourcePath nor acrName are provided.",
         "PackCliInstallFailed": "Unable to install pack CLI.",

--- a/azurecontainerapps/task.loc.json
+++ b/azurecontainerapps/task.loc.json
@@ -147,6 +147,13 @@
       "label": "ms-resource:loc.input.label.environmentVariables",
       "required": false,
       "helpMarkDown": "ms-resource:loc.input.help.environmentVariables"
+    },
+    {
+      "name": "disableTelemetry",
+      "type": "boolean",
+      "label": "ms-resource:loc.input.label.disableTelemetry",
+      "required": false,
+      "helpMarkDown": "ms-resource:loc.input.help.disableTelemetry"
     }
   ],
   "execution": {
@@ -180,6 +187,7 @@
     "ErrorCodeFormat": "ms-resource:loc.messages.ErrorCodeFormat",
     "ErrorMessageFormat": "ms-resource:loc.messages.ErrorMessageFormat",
     "FoundAppSourceDockerfileMessage": "ms-resource:loc.messages.FoundAppSourceDockerfileMessage",
+    "LogTelemetryFailed": "ms-resource:loc.messages.LogTelemetryFailed",
     "MissingAcrNameMessage": "ms-resource:loc.messages.MissingAcrNameMessage",
     "MissingImageToDeployMessage": "ms-resource:loc.messages.MissingImageToDeployMessage",
     "PackCliInstallFailed": "ms-resource:loc.messages.PackCliInstallFailed",

--- a/azurecontainerapps/task.loc.json
+++ b/azurecontainerapps/task.loc.json
@@ -19,7 +19,7 @@
   "version": {
     "Major": 0,
     "Minor": 1,
-    "Patch": 10
+    "Patch": 11
   },
   "minimumAgentVersion": "2.144.0",
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -2,7 +2,7 @@
     "manifestVersion": 1,
     "id": "AzureContainerAppsRC",
     "name": "Azure Container Apps Deploy (Release Candidate)",
-    "version": "0.1.10",
+    "version": "0.1.11",
     "publisher": "microsoft-oryx",
     "public": true,
     "targets": [


### PR DESCRIPTION
Equivalent to the change made in the [`container-apps-deploy-action` repository](https://github.com/Azure/container-apps-deploy-action/pull/22).

This PR introduces telemetry that tracks the following:
- The scenario targeted by the user
  - _i.e._, used builder, used Dockerfile, used image
- The time (in milliseconds) it took to execute the action
- The result of the action
  - _i.e._, succeeded or failed

This PR also introduces the `disableTelemetry` argument to allow users to opt out of Microsoft collecting data about their execution of the action.