### PR TITLE
Catch any exceptions thrown when logging telemetry and continue

### DIFF
--- a/azurecontainerapps/Strings/resources.resjson/en-US/resources.resjson
+++ b/azurecontainerapps/Strings/resources.resjson/en-US/resources.resjson
@@ -60,7 +60,6 @@
   "loc.messages.ErrorCodeFormat": "Error Code: [%s]",
   "loc.messages.ErrorMessageFormat": "Error: %s",
   "loc.messages.FoundAppSourceDockerfileMessage": "Found existing Dockerfile in provided application source at path '%s'; image will be built from this Dockerfile.",
-  "loc.messages.LogTelemetryFailed": "Unable to log telemetry to Application Insights.",
   "loc.messages.MissingAcrNameMessage": "The acrName argument must also be provided if the appSourcePath argument is provided.",
   "loc.messages.MissingImageToDeployMessage": "The argument imageToDeploy must be provided if neither appSourcePath nor acrName are provided.",
   "loc.messages.PackCliInstallFailed": "Unable to install pack CLI.",

--- a/azurecontainerapps/Strings/resources.resjson/en-US/resources.resjson
+++ b/azurecontainerapps/Strings/resources.resjson/en-US/resources.resjson
@@ -36,6 +36,8 @@
   "loc.input.help.location": "The location that the Container App (and other created resources) will be deployed to.",
   "loc.input.label.environmentVariables": "Environment variables",
   "loc.input.help.environmentVariables": "A list of environment variable(s) for the container. Space-separated values in 'key=value' format. Empty string to clear existing values. Prefix value with 'secretref:' to reference a secret.",
+  "loc.input.label.disableTelemetry": "Disable telemetry",
+  "loc.input.help.disableTelemetry": "If set to 'true', no telemetry will be collected by this Azure DevOps Task. If set to 'false', or if this argument is not provided, telemetry will be sent to Microsoft about the Container App build and deploy scenario targeted by this Azure DevOps Task.",
   "loc.messages.AcrAccessTokenAuthFailed": "Unable to authenticate against ACR instance '%s.azurecr.io' with access token.",
   "loc.messages.AcrAccessTokenLoginMessage": "Logging in to Azure Container Registry using access token to be generated via Azure CLI.",
   "loc.messages.AcrUsernamePasswordAuthFailed": "Unable to authenticate against ACR instance '%s.azurecr.io' with username/password.",

--- a/azurecontainerapps/src/TelemetryHelper.ts
+++ b/azurecontainerapps/src/TelemetryHelper.ts
@@ -86,10 +86,9 @@ export class TelemetryHelper {
 
                 const dockerCommand = `run --rm ${ORYX_CLI_IMAGE} /bin/bash -c "oryx telemetry --event-name 'ContainerAppsPipelinesTaskRC' ` +
                 `--processing-time '${taskLengthMilliseconds}' ${resultArg} ${scenarioArg} ${errorMessageArg}"`
-                new Utility().throwIfError(
-                    tl.execSync('docker', dockerCommand),
-                    tl.loc('LogTelemetryFailed')
-                );
+
+                // Don't use Utility's throwIfError() since it will still record an error in the pipeline logs, but won't fail the task
+                tl.execSync('docker', dockerCommand)
             } catch (err) {
                 tl.warning(`Skipping telemetry logging due to the following exception: ${err.message}`);
             }

--- a/azurecontainerapps/src/TelemetryHelper.ts
+++ b/azurecontainerapps/src/TelemetryHelper.ts
@@ -91,8 +91,7 @@ export class TelemetryHelper {
                     tl.loc('LogTelemetryFailed')
                 );
             } catch (err) {
-                tl.error(err.message);
-                throw err;
+                tl.warning(`Skipping telemetry logging due to the following exception: ${err.message}`);
             }
         }
     }

--- a/azurecontainerapps/task.json
+++ b/azurecontainerapps/task.json
@@ -187,7 +187,6 @@
         "ErrorCodeFormat": "Error Code: [%s]",
         "ErrorMessageFormat": "Error: %s",
         "FoundAppSourceDockerfileMessage": "Found existing Dockerfile in provided application source at path '%s'; image will be built from this Dockerfile.",
-        "LogTelemetryFailed": "Unable to log telemetry to Application Insights.",
         "MissingAcrNameMessage": "The acrName argument must also be provided if the appSourcePath argument is provided.",
         "MissingImageToDeployMessage": "The argument imageToDeploy must be provided if neither appSourcePath nor acrName are provided.",
         "PackCliInstallFailed": "Unable to install pack CLI.",

--- a/azurecontainerapps/task.json
+++ b/azurecontainerapps/task.json
@@ -19,7 +19,7 @@
     "version": {
         "Major": 0,
         "Minor": 1,
-        "Patch": 11
+        "Patch": 12
     },
     "minimumAgentVersion": "2.144.0",
     "instanceNameFormat": "Azure Container Apps Deploy (Release Candidate)",

--- a/azurecontainerapps/task.loc.json
+++ b/azurecontainerapps/task.loc.json
@@ -187,7 +187,6 @@
     "ErrorCodeFormat": "ms-resource:loc.messages.ErrorCodeFormat",
     "ErrorMessageFormat": "ms-resource:loc.messages.ErrorMessageFormat",
     "FoundAppSourceDockerfileMessage": "ms-resource:loc.messages.FoundAppSourceDockerfileMessage",
-    "LogTelemetryFailed": "ms-resource:loc.messages.LogTelemetryFailed",
     "MissingAcrNameMessage": "ms-resource:loc.messages.MissingAcrNameMessage",
     "MissingImageToDeployMessage": "ms-resource:loc.messages.MissingImageToDeployMessage",
     "PackCliInstallFailed": "ms-resource:loc.messages.PackCliInstallFailed",

--- a/azurecontainerapps/task.loc.json
+++ b/azurecontainerapps/task.loc.json
@@ -19,7 +19,7 @@
   "version": {
     "Major": 0,
     "Minor": 1,
-    "Patch": 11
+    "Patch": 12
   },
   "minimumAgentVersion": "2.144.0",
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -2,7 +2,7 @@
     "manifestVersion": 1,
     "id": "AzureContainerAppsRC",
     "name": "Azure Container Apps Deploy (Release Candidate)",
-    "version": "0.1.11",
+    "version": "0.1.12",
     "publisher": "microsoft-oryx",
     "public": true,
     "targets": [


### PR DESCRIPTION
Resolves issue https://github.com/Azure/container-apps-deploy-pipelines-task/issues/20

Prevents the attempt to log telemetry from recording an error and/or failing the task, which would affect the result of the Azure Pipeline executing.