### PR TITLE
Updated check for OS used when executing task

### DIFF
--- a/azurecontainerapps/Strings/resources.resjson/en-US/resources.resjson
+++ b/azurecontainerapps/Strings/resources.resjson/en-US/resources.resjson
@@ -3,7 +3,7 @@
   "loc.helpMarkDown": "[Learn more about this task](http://github.com/microsoft/azure-pipelines-tasks/blob/master/Tasks/AzureContainerAppsV0/README.md)",
   "loc.description": "An Azure DevOps Task to build and deploy Azure Container Apps.",
   "loc.instanceNameFormat": "Azure Container Apps Deploy (Release Candidate)",
-  "loc.releaseNotes": "Fixed failing Dockerfile scenarios, added error handling for miscellaneous calls.",
+  "loc.releaseNotes": "Updated check for OS used when executing task.",
   "loc.input.label.cwd": "Working Directory",
   "loc.input.help.cwd": "Current working directory where the script is run.  Empty is the root of the repo (build) or artifacts (release), which is $(System.DefaultWorkingDirectory)",
   "loc.input.label.appSourcePath": "Application source path",

--- a/azurecontainerapps/src/CommandHelper.ts
+++ b/azurecontainerapps/src/CommandHelper.ts
@@ -1,3 +1,4 @@
+import * as os from 'os'
 import * as tl from 'azure-pipelines-task-lib/task';
 import * as tr from 'azure-pipelines-task-lib/toolrunner';
 
@@ -10,7 +11,7 @@ export class CommandHelper {
      * @returns the string output from the command
      */
     public async execCommandAsync(command: string, cwd?: string) : Promise<string> {
-        return tl.getVariable('AGENT.OS') == 'Windows_NT' ?
+        return os.platform() == 'win32' ?
             this.execPwshCommandAsync(command, cwd) :
             this.execBashCommandAsync(command, cwd);
     }

--- a/azurecontainerapps/src/ContainerAppHelper.ts
+++ b/azurecontainerapps/src/ContainerAppHelper.ts
@@ -6,8 +6,7 @@ import { Utility } from './Utility';
 
 const ORYX_CLI_IMAGE: string = 'mcr.microsoft.com/oryx/cli:builder-debian-buster-20230208.1';
 const ORYX_BUILDER_IMAGE: string = 'mcr.microsoft.com/oryx/builder:20230208.1';
-const AGENT_OS: string = tl.getVariable('AGENT.OS');
-const IS_WINDOWS_AGENT: boolean = AGENT_OS == 'Windows_NT';
+const IS_WINDOWS_AGENT: boolean = os.platform() == 'win32';
 const PACK_CMD: string = IS_WINDOWS_AGENT ? path.join(os.tmpdir(), 'pack') : 'pack';
 
 export class ContainerAppHelper {
@@ -169,7 +168,7 @@ export class ContainerAppHelper {
                           `Expand-Archive -LiteralPath ${packZipDownloadFilePath} -DestinationPath ${PACK_CMD}; ` +
                           `Remove-Item -Path ${packZipDownloadFilePath}`;
             } else {
-                const tgzSuffix = AGENT_OS == 'Darwin' ? 'macos' : 'linux';
+                const tgzSuffix = os.platform() == 'darwin' ? 'macos' : 'linux';
                 command = `(curl -sSL \"https://github.com/buildpacks/pack/releases/download/v0.27.0/pack-v0.27.0-${tgzSuffix}.tgz\" | ` +
                                   'tar -C /usr/local/bin/ --no-same-owner -xzv pack)';
             }

--- a/azurecontainerapps/task.json
+++ b/azurecontainerapps/task.json
@@ -6,7 +6,7 @@
     "description": "An Azure DevOps Task to build and deploy Azure Container Apps.",
     "author": "Microsoft Corporation",
     "helpMarkDown": "[Learn more about this task](http://github.com/Azure/container-apps-deploy-pipelines-task)",
-    "releaseNotes": "Fixed failing Dockerfile scenarios, added error handling for miscellaneous calls.",
+    "releaseNotes": "Updated check for OS used when executing task.",
     "category": "Deploy",
     "visibility": [
         "Build",
@@ -19,7 +19,7 @@
     "version": {
         "Major": 0,
         "Minor": 1,
-        "Patch": 12
+        "Patch": 13
     },
     "minimumAgentVersion": "2.144.0",
     "instanceNameFormat": "Azure Container Apps Deploy (Release Candidate)",

--- a/azurecontainerapps/task.loc.json
+++ b/azurecontainerapps/task.loc.json
@@ -19,7 +19,7 @@
   "version": {
     "Major": 0,
     "Minor": 1,
-    "Patch": 12
+    "Patch": 13
   },
   "minimumAgentVersion": "2.144.0",
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -2,7 +2,7 @@
     "manifestVersion": 1,
     "id": "AzureContainerAppsRC",
     "name": "Azure Container Apps Deploy (Release Candidate)",
-    "version": "0.1.12",
+    "version": "0.1.13",
     "publisher": "microsoft-oryx",
     "public": true,
     "targets": [


### PR DESCRIPTION
In the stable monorepo, many tasks are checking the OS used when executing a task via the [`os.platform()`](https://nodejs.org/api/os.html#osplatform) method, and any task referencing the `AGENT.OS` environment variable is doing so only for telemetry, so this PR aims to update the logic so that we're in-line with what other tasks are using for checking OS.