### PR TITLE
Fixing Http 400 Error and Using MI when Updating Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Services tab in the settings section. Add the Azure subscription to use in the B
 opening the Account Administration screen (gear icon on the top-right of the screen) and then click on the Services Tab.
 
 Create the [ARM](https://azure.microsoft.com/en-in/documentation/articles/resource-group-overview/) service endpoint and
-use the **'Azure Resource Manager'** endpoint type; for more information on creating service connections, please follow
+use the **'Azure Resource Manager'** endpoint type and choose **Service Principal** authentication method; for more information on creating service connections, please follow
 [this document](https://learn.microsoft.com/en-us/azure/devops/pipelines/library/service-endpoints).
 
 ### Azure CLI

--- a/azurecontainerapps/Strings/resources.resjson/en-US/resources.resjson
+++ b/azurecontainerapps/Strings/resources.resjson/en-US/resources.resjson
@@ -3,7 +3,7 @@
   "loc.helpMarkDown": "[Learn more about this task](http://github.com/microsoft/azure-pipelines-tasks/blob/master/Tasks/AzureContainerAppsV0/README.md)",
   "loc.description": "An Azure DevOps Task to build and deploy Azure Container Apps.",
   "loc.instanceNameFormat": "Azure Container Apps Deploy (Release Candidate)",
-  "loc.releaseNotes": "Update telemetry caller ID to reflect new version of RC task.",
+  "loc.releaseNotes": "Fixed Http 400 error and ingress update error when using MI to update apps.",
   "loc.input.label.cwd": "Working Directory",
   "loc.input.help.cwd": "Current working directory where the script is run.  Empty is the root of the repo (build) or artifacts (release), which is $(System.DefaultWorkingDirectory)",
   "loc.input.label.appSourcePath": "Application source path",

--- a/azurecontainerapps/Strings/resources.resjson/en-US/resources.resjson
+++ b/azurecontainerapps/Strings/resources.resjson/en-US/resources.resjson
@@ -80,6 +80,7 @@
   "loc.messages.PushImageToAcrFailed": "Unable to push image '%s' to ACR.",
   "loc.messages.SetDefaultBuilderFailed": "Unable to set the Oryx++ Builder as the default builder.",
   "loc.messages.UpdateContainerAppFailed": "Unable to update Azure Container App via 'az containerapp update' command.",
+  "loc.messages.UpdateContainerAppIngressFailed": "Unable to update Azure Container App ingress via 'az containerapp ingress update' command.",
   "loc.messages.UpdateContainerAppFromYamlFailed": "Unable to update Azure Container App from YAML configuration file via 'az containerapp update' command.",
   "loc.messages.UpdateContainerAppRegistryDetailsFailed": "Unable to update Azure Container App ACR details via 'az containerapp registry set' command."
 }

--- a/azurecontainerapps/azurecontainerapps.ts
+++ b/azurecontainerapps/azurecontainerapps.ts
@@ -88,6 +88,7 @@ export class azurecontainerapps {
     private static ingressEnabled: boolean;
 
     // ACR properties
+    private static adminCredentialsProvided: boolean;
     private static acrUsername: string;
     private static acrPassword: string;
 
@@ -105,7 +106,7 @@ export class azurecontainerapps {
     private static runtimeStack: string;
     private static ingress: string;
     private static targetPort: string;
-    private static shouldUseUpdateCommand: boolean;
+    private static noIngressUpdate: boolean;
 
     /**
      * Initializes the helpers used by this task.
@@ -418,13 +419,14 @@ export class azurecontainerapps {
 
         // If both ingress and target port were not provided for an existing Container App, or if ingress is to be disabled,
         // use the 'update' command, otherwise we should use the 'up' command that performs a PATCH operation on the ingress properties.
-        this.shouldUseUpdateCommand = this.containerAppExists &&
-                                      util.isNullOrEmpty(this.targetPort) &&
-                                      (util.isNullOrEmpty(this.ingress) || this.ingress == 'disabled');
+        this.noIngressUpdate = this.containerAppExists &&
+            util.isNullOrEmpty(this.targetPort) &&
+            (util.isNullOrEmpty(this.ingress) || this.ingress == 'disabled');
 
         // Pass the ACR credentials when creating a Container App or updating a Container App via the 'up' command
         if (!util.isNullOrEmpty(this.acrName) && !util.isNullOrEmpty(this.acrUsername) && !util.isNullOrEmpty(this.acrPassword) &&
-            (!this.containerAppExists || (this.containerAppExists && !this.shouldUseUpdateCommand))) {
+            (!this.containerAppExists || (this.containerAppExists && !this.noIngressUpdate))) {
+            this.adminCredentialsProvided = true;
             this.commandLineArgs.push(
                 `--registry-server ${this.acrName}.azurecr.io`,
                 `--registry-username ${this.acrUsername}`,
@@ -475,12 +477,13 @@ export class azurecontainerapps {
         }
 
         const environmentVariables: string = tl.getInput('environmentVariables', false);
+        const isCappUpdateCommandUsed: boolean = this.noIngressUpdate || (!this.noIngressUpdate && !this.adminCredentialsProvided);
 
         // Add user-specified environment variables
         if (!util.isNullOrEmpty(environmentVariables)) {
             // The --replace-env-vars flag is only used for the 'update' command,
             // otherwise --env-vars is used for 'create' and 'up'
-            if (this.shouldUseUpdateCommand) {
+            if (isCappUpdateCommandUsed) {
                 this.commandLineArgs.push(`--replace-env-vars ${environmentVariables}`);
             } else {
                 this.commandLineArgs.push(`--env-vars ${environmentVariables}`);
@@ -511,7 +514,7 @@ export class azurecontainerapps {
             return;
         }
 
-        if (this.shouldUseUpdateCommand) {
+        if (this.noIngressUpdate) {
             // Update the ACR details on the existing Container App, if provided as an input
             if (!util.isNullOrEmpty(this.acrName) && !util.isNullOrEmpty(this.acrUsername) && !util.isNullOrEmpty(this.acrPassword)) {
                 this.appHelper.updateContainerAppRegistryDetails(this.containerAppName, this.resourceGroup, this.acrName, this.acrUsername, this.acrPassword);
@@ -519,9 +522,13 @@ export class azurecontainerapps {
 
             // Update the Container App using the 'update' command
             this.appHelper.updateContainerApp(this.containerAppName, this.resourceGroup, this.imageToDeploy, this.commandLineArgs);
-        } else {
-            // Update the Container App using the 'up' command
+        } else if (this.adminCredentialsProvided && !this.noIngressUpdate) {
+            // Update the Container App with `up` command when admin credentials are provided and ingress is manually provided.
             this.appHelper.updateContainerAppWithUp(this.containerAppName, this.resourceGroup, this.imageToDeploy, this.commandLineArgs, this.ingress, this.targetPort);
+        } else {
+            // Update the Container App using the 'containerapp update' and 'ingress update' commands
+            this.appHelper.updateContainerApp(this.containerAppName, this.resourceGroup, this.imageToDeploy, this.commandLineArgs);
+            this.appHelper.updateContainerAppIngress(this.containerAppName, this.resourceGroup, this.ingress, this.targetPort);
         }
 
         // Disable ingress on the existing Container App, if provided as an input

--- a/azurecontainerapps/src/ContainerAppHelper.ts
+++ b/azurecontainerapps/src/ContainerAppHelper.ts
@@ -143,6 +143,40 @@ export class ContainerAppHelper {
         }
 
     /**
+     * Update container app with update and ingress update to avoid failure of acr authentication.
+     * @param containerAppName - the name of the existing Container App
+     * @param resourceGroup - the resource group that the existing Container App is found in
+     * @param ingress - the ingress that the Container App will be exposed on
+     * @param targetPort - the target port that the Container App will be exposed on
+     */
+    public updateContainerAppIngress(
+        containerAppName: string,
+        resourceGroup: string,
+        ingress?: string,
+        targetPort?: string) {
+            tl.debug(`Attempting to update Container App ingress with name "${containerAppName}" in resource group "${resourceGroup}"`);
+            const util = new Utility();
+            try {
+                let command = `containerapp ingress update -n ${containerAppName} -g ${resourceGroup}`;
+                if (!util.isNullOrEmpty(ingress)) {
+                    command += ` --ingress ${ingress}`;
+                }
+
+                if (!util.isNullOrEmpty(targetPort)) {
+                    command += ` --target-port ${targetPort}`;
+                }
+
+                util.throwIfError(
+                    tl.execSync('az', command),
+                    tl.loc('UpdateContainerAppIngressFailed')
+                )
+            } catch (err) {
+                tl.error(err.message);
+                throw err;
+            }
+    }
+    
+    /**
      * Updates an existing Azure Container App based from a YAML configuration file.
      * @param containerAppName - the name of the existing Container App
      * @param resourceGroup - the resource group that the existing Container App is found in
@@ -266,7 +300,7 @@ export class ContainerAppHelper {
         try {
             const command = `containerapp env list -g ${resourceGroup} --query [0].name"`;
             const result = tl.execSync('az', command);
-            return result.code == 0 ? result.stdout : null;
+            return result.code == 0 ? result.stdout.replace(/(\r\n|\n|\r)/gm, "") : null;
         } catch (err) {
             tl.warning(err.message);
             return null;

--- a/azurecontainerapps/src/ContainerAppHelper.ts
+++ b/azurecontainerapps/src/ContainerAppHelper.ts
@@ -159,7 +159,7 @@ export class ContainerAppHelper {
             try {
                 let command = `containerapp ingress update -n ${containerAppName} -g ${resourceGroup}`;
                 if (!util.isNullOrEmpty(ingress)) {
-                    command += ` --ingress ${ingress}`;
+                    command += ` --type ${ingress}`;
                 }
 
                 if (!util.isNullOrEmpty(targetPort)) {

--- a/azurecontainerapps/task.json
+++ b/azurecontainerapps/task.json
@@ -19,7 +19,7 @@
     "version": {
         "Major": 1,
         "Minor": 0,
-        "Patch": 1
+        "Patch": 4
     },
     "minimumAgentVersion": "2.144.0",
     "instanceNameFormat": "Azure Container Apps Deploy (Release Candidate)",

--- a/azurecontainerapps/task.json
+++ b/azurecontainerapps/task.json
@@ -217,6 +217,7 @@
         "PushImageToAcrFailed": "Unable to push image '%s' to ACR.",
         "SetDefaultBuilderFailed": "Unable to set the Oryx++ Builder as the default builder.",
         "UpdateContainerAppFailed": "Unable to update Azure Container App via 'az containerapp update' command.",
+        "UpdateContainerAppIngressFailed": "Unable to update Azure Container App ingress via 'az containerapp ingress update' command.",
         "UpdateContainerAppFromYamlFailed": "Unable to update Azure Container App from YAML configuration file via 'az containerapp update' command.",
         "UpdateContainerAppRegistryDetailsFailed": "Unable to update Azure Container App ACR details via 'az containerapp registry set' command."
     }

--- a/azurecontainerapps/task.loc.json
+++ b/azurecontainerapps/task.loc.json
@@ -217,6 +217,7 @@
     "PushImageToAcrFailed": "ms-resource:loc.messages.PushImageToAcrFailed",
     "SetDefaultBuilderFailed": "ms-resource:loc.messages.SetDefaultBuilderFailed",
     "UpdateContainerAppFailed": "ms-resource:loc.messages.UpdateContainerAppFailed",
+    "UpdateContainerAppIngressFailed": "ms-resource:loc.messages.UpdateContainerAppIngressFailed",
     "UpdateContainerAppFromYamlFailed": "ms-resource:loc.messages.UpdateContainerAppFromYamlFailed",
     "UpdateContainerAppRegistryDetailsFailed": "ms-resource:loc.messages.UpdateContainerAppRegistryDetailsFailed"
   }

--- a/azurecontainerapps/task.loc.json
+++ b/azurecontainerapps/task.loc.json
@@ -19,7 +19,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 1
+    "Patch": 4
   },
   "minimumAgentVersion": "2.144.0",
   "instanceNameFormat": "ms-resource:loc.instanceNameFormat",

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -2,7 +2,7 @@
     "manifestVersion": 1,
     "id": "AzureContainerAppsRC",
     "name": "Azure Container Apps Deploy (Release Candidate)",
-    "version": "1.0.1",
+    "version": "1.0.4",
     "publisher": "microsoft-oryx",
     "public": true,
     "targets": [


### PR DESCRIPTION
<!-- PLEASE DO NOT DELETE THIS TEMPLATE -->

## Description

<!-- Please include a brief description of the changes made in this PR. -->

## Issue

<!-- If possible, please include a link to the GitHub issue or ADO work item associated with this change. If none exists, please put down "N/A". -->

## Building the task

<!-- Please check the following boxes that correspond with building the task. -->

- [x] `npm install` was ran within the `azurecontainerapps` folder to regenerate the `package-lock.json` file
- [x] `tsc` was ran within the `azurecontainerapps` folder to ensure all TypeScript was successfully compiled into JavaScript

## Testing the task

<!-- Please check the following boxes that correspond with testing the task. -->

- [x] A new version of the `AzureContainerAppsTest` task was generated with these changes and published
  - [ ] The task was ran against the existing test suite to ensure backwards compatibility
  - [x] The task was ran against a workflow that tests the changes introduced in this PR
- [x] The local TypeScript code was tested against the `mocha` tests

## Deploying the task

<!-- Please check the following boxes that correspond with deploying the task. -->

- [ ] New argument(s) was added
  - [ ] The `inputs` array was updated in `task.json` to reflect the new argument(s)
  - [ ] The `inputs` array was updated in `task.loc.json` to reflect the new argument(s)
  - [ ] The corresponding `loc` properties were updated in `resources.resjson` to reflect the new argument(s)
- [x] New version of the task
  - [x] The `version` property was updated in `task.json` to reflect the new version
  - [x] The `version` property was updated in `task.loc.json` to reflect the new version
  - [x] The `version` property was updated in `vss-extension.json` to reflect the new version
  - [x] The `releaseNotes` property was updated in `task.json` to reflect the changes made since the last release
  - [x] The `releaseNotes` property was updated in `resources.resjson` to reflect the changes made since the last release